### PR TITLE
Apostrophe Fix

### DIFF
--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -137,7 +137,7 @@ module.exports = {
     return {
       'Fn::Join': [
         '', [
-          "#set( $body = $util.escapeJavaScript($input.json('$')) ) \n\n",
+          "#set( $body = $util.escapeJavaScript($input.json('$')).replaceAll(\"\\\\'\", \"'\") ) \n\n",
           '{"input": "$body","name": "$context.requestId","stateMachineArn":"',
           {
             Ref: `${stateMachineLogicalId}`,


### PR DESCRIPTION
This commit fixes the problem in the serverless plugin which resulted in
SerializationException if the data consisted of an Apostrophe. Please
refer to fix in
https://github.com/horike37/serverless-step-functions/pull/141/commits/eb37e03a56dbd97bf49637e4f9aefece6f8964b6